### PR TITLE
Add Sharpei to Docker Hub

### DIFF
--- a/.github/workflows/push-to-docker.yml
+++ b/.github/workflows/push-to-docker.yml
@@ -1,0 +1,31 @@
+name: Push to Docker
+
+on: [workflow_dispatch]
+
+jobs:
+    docker-push:
+        runs-on: ubuntu-latest
+        env:
+            DOCKER_BUILDKIT: 1
+
+        steps:
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v1
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v1
+
+            - name: Login to DockerHub
+              uses: docker/login-action@v1
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+            - name: Docker Build and Push
+              uses: docker/build-push-action@v2
+              with:
+                  context: .
+                  file: ./Dockerfile
+                  platforms: linux/amd64,linux/arm64,linux/386
+                  push: true
+                  tags: polymathian/sharpei:latest

--- a/.github/workflows/push-to-docker.yml
+++ b/.github/workflows/push-to-docker.yml
@@ -1,6 +1,8 @@
 name: Push to Docker
 
-on: [workflow_dispatch]
+on:
+    release:
+        types: [published]
 
 jobs:
     docker-push:
@@ -28,4 +30,6 @@ jobs:
                   file: ./Dockerfile
                   platforms: linux/amd64,linux/arm64,linux/386
                   push: true
-                  tags: polymathian/sharpei:latest
+                  tags: |
+                      polymathian/sharpei:latest
+                      polymathian/sharpei:${{ github.event.release.tag_name }}

--- a/.github/workflows/push-to-docker.yml
+++ b/.github/workflows/push-to-docker.yml
@@ -9,8 +9,13 @@ jobs:
         runs-on: ubuntu-latest
         env:
             DOCKER_BUILDKIT: 1
+            VERSION: ${{github.event.release.tag_name}}
 
         steps:
+            - name: Set version string
+              id: vars
+              run: echo ::set-output name=release_version::${VERSION##*v}
+
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v1
 
@@ -32,4 +37,4 @@ jobs:
                   push: true
                   tags: |
                       polymathian/sharpei:latest
-                      polymathian/sharpei:${{ github.event.release.tag_name }}
+                      polymathian/sharpei:${{ steps.vars.outputs.release_version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.6-slim
+
+COPY . /app
+WORKDIR /app
+
+RUN mkdir /data
+RUN pip3 install -e .
+
+ENTRYPOINT [ "sharpei",  "/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.9-slim-buster
 
 COPY . /app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -6,13 +6,17 @@ Requires Python 3.6+
 
 ## Usage
 
+Sharpei can be run from the CLI or Docker.
+
+#### CLI
+
 Install from [PyPI](https://pypi.org/project/sharpei/)
 
 ```bash
 pip install sharpei
 ```
 
-#### CLI
+To run:
 
 ```bash
 # Monitor the current directory and send all files
@@ -21,9 +25,9 @@ pip install sharpei
 
 Use `sharpei --help` to discover additional options
 
-#### DockerHub
+#### Docker
 
-You will need to mount a directory to the Docker image.
+You will need to mount a directory to the Docker image as `/data`.
 
 ```bash
 > docker run --mount type=bind,source=YOUR_DIRECTORY,target=/data sharpei s3://bucket/key-prefix
@@ -43,5 +47,5 @@ working-dir
 To monitor file changes in `target-folder`, run:
 
 ```bash
-> docker run --mount type=bind,source="$(pwd)"/target-folder,target=/data sharpei s3://my-bucket/my-prefix
+> docker run --mount type=bind,source="$(pwd)"/target-folder,target=/data polymathian/sharpei s3://my-bucket/my-prefix
 ```

--- a/README.md
+++ b/README.md
@@ -13,9 +13,35 @@ pip install sharpei
 ```
 
 #### CLI
+
 ```bash
 # Monitor the current directory and send all files
 > sharpei . s3://bucket/key-prefix/
 ```
 
 Use `sharpei --help` to discover additional options
+
+#### DockerHub
+
+You will need to mount a directory to the Docker image.
+
+```bash
+> docker run --mount type=bind,source=YOUR_DIRECTORY,target=/data sharpei s3://bucket/key-prefix
+```
+
+For example, given a folder structure:
+
+```
+working-dir
+│   README.md
+|
+└───target-folder
+        file011.txt
+        file012.txt
+```
+
+To monitor file changes in `target-folder`, run:
+
+```bash
+> docker run --mount type=bind,source="$(pwd)"/target-folder,target=/data sharpei s3://my-bucket/my-prefix
+```


### PR DESCRIPTION
Adds Sharpei to Dockerhub.

Tested on a EC2 instance using Ubuntu 20.04. Does not work on Windows.

The readme has been updated to include instructions on how to get this running.